### PR TITLE
feat(validator): add per-domain allowDynamicValues flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/forman-schema",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "license": "MIT",
             "devDependencies": {
                 "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "description": "Forman Schema Tools",
     "license": "MIT",
     "author": "Make",

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,9 @@ export function validateFormanWithDomains(
             schema: FormanSchemaField[];
             /** Extra values injected into restore states, keyed by string path (dot notation, `[index]`, backtick-escaping). */
             restoreExtras?: Record<string, Record<string, unknown>>;
+            /** Whether the domain allows dynamic values (IML expressions, unresolved RPC select options).
+             *  Defaults to false. When false, IML expressions cause errors and unresolved RPC options are treated as errors. */
+            allowDynamicValues?: boolean;
         }
     >,
     options?: FormanValidationOptions,
@@ -76,5 +79,8 @@ export function validateForman(
     options?: FormanValidationOptions,
     restoreExtras?: Record<string, Record<string, unknown>>,
 ): Promise<FormanValidationResult> {
-    return validateFormanWithDomains({ default: { values, schema, restoreExtras } }, options);
+    return validateFormanWithDomains(
+        { default: { values, schema, restoreExtras, allowDynamicValues: options?.allowDynamicValues } },
+        options,
+    );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -294,4 +294,7 @@ export type FormanValidationOptions = {
     resolveRemote?(path: string, data: Record<string, unknown>): Promise<unknown>;
     /** Maps domain names used in nested.domain to actual domain keys passed to validateFormanWithDomains */
     domainAliases?: Record<string, string>;
+    /** Whether to allow dynamic values (IML expressions, unresolved RPC options).
+     *  When false (default), IML expressions cause errors and unresolved RPC options are treated as errors */
+    allowDynamicValues?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -295,6 +295,7 @@ export type FormanValidationOptions = {
     /** Maps domain names used in nested.domain to actual domain keys passed to validateFormanWithDomains */
     domainAliases?: Record<string, string>;
     /** Whether to allow dynamic values (IML expressions, unresolved RPC options).
-     *  When false (default), IML expressions cause errors and unresolved RPC options are treated as errors */
+     *  When false (default), IML expressions cause errors and unresolved RPC options are treated as errors.
+     *  Applies as a global default; can be overridden per-domain in validateFormanWithDomains(). */
     allowDynamicValues?: boolean;
 };

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -82,6 +82,8 @@ export interface DomainRoot {
     }>;
     /** Resolved schema fields collected during validation */
     schemaFields: FormanSchemaField[];
+    /** Whether the domain allows dynamic values (IML expressions, unresolved RPC select options) */
+    allowDynamicValues: boolean;
 }
 
 /**
@@ -212,6 +214,7 @@ export async function validateFormanWithDomainsInternal(
             values: Record<string, unknown>;
             schema?: FormanSchemaField[];
             restoreExtras?: Record<string, Record<string, unknown>>;
+            allowDynamicValues?: boolean;
         }
     >,
     options?: FormanValidationOptions,
@@ -225,6 +228,7 @@ export async function validateFormanWithDomainsInternal(
                 seenFields: new Set(),
                 fieldStates: [],
                 schemaFields: [],
+                allowDynamicValues: domains[domain]!.allowDynamicValues ?? false,
                 validateFields: (fields: FormanSchemaField[], context: ValidationContext) => {
                     return validateFormanValue(
                         domains[domain]!.values,
@@ -417,7 +421,7 @@ async function validateFormanValue(
     }
 
     if (containsIMLExpression(value)) {
-        if (normalizedField.mappable === false) {
+        if (normalizedField.mappable === false || !context.roots[context.domain]!.allowDynamicValues) {
             return {
                 valid: false,
                 errors: [
@@ -1008,7 +1012,7 @@ async function handleSelectType(
                 optionsOrGroups as FormanSchemaSelectOptionsStore,
             );
             if (!found) {
-                (optionsFromRPC ? warnings : errors).push({
+                (optionsFromRPC && context.roots[context.domain]!.allowDynamicValues ? warnings : errors).push({
                     domain: context.domain,
                     path: context.path.join('.'),
                     message: `Value '${singleValue}' not found in options.`,
@@ -1017,7 +1021,7 @@ async function handleSelectType(
             }
         }
 
-        if (optionsFromRPC && hasUnresolvedValue) {
+        if (optionsFromRPC && context.roots[context.domain]!.allowDynamicValues && hasUnresolvedValue) {
             context.roots[context.domain]!.fieldStates.push({
                 path: context.path,
                 state: { mode: 'edit' },
@@ -1063,7 +1067,7 @@ async function handleSelectType(
         const item = findValueInSelectOptions(field, value, optionsOrGroups as FormanSchemaSelectOptionsStore);
 
         if (!item) {
-            if (optionsFromRPC) {
+            if (optionsFromRPC && context.roots[context.domain]!.allowDynamicValues) {
                 warnings.push({
                     domain: context.domain,
                     path: context.path.join('.'),

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -228,7 +228,7 @@ export async function validateFormanWithDomainsInternal(
                 seenFields: new Set(),
                 fieldStates: [],
                 schemaFields: [],
-                allowDynamicValues: domains[domain]!.allowDynamicValues ?? false,
+                allowDynamicValues: domains[domain]!.allowDynamicValues ?? options?.allowDynamicValues ?? false,
                 validateFields: (fields: FormanSchemaField[], context: ValidationContext) => {
                     return validateFormanValue(
                         domains[domain]!.values,

--- a/test/allow-dynamic-values.spec.ts
+++ b/test/allow-dynamic-values.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from '@jest/globals';
+import { validateForman, validateFormanWithDomains } from '../src/index.js';
+import type { FormanSchemaField } from '../src/index.js';
+
+describe('allowDynamicValues', () => {
+    describe('IML expressions', () => {
+        it('should reject IML when allowDynamicValues is false (default)', async () => {
+            const result = await validateForman({ name: '{{1.name}}' }, [{ name: 'name', type: 'text' }]);
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: 'Value contains prohibited IML expression.' }),
+            ]);
+        });
+
+        it('should accept IML when allowDynamicValues is true', async () => {
+            const result = await validateForman({ name: '{{1.name}}' }, [{ name: 'name', type: 'text' }], {
+                allowDynamicValues: true,
+            });
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+
+        it('should still reject IML when field.mappable is explicitly false even with allowDynamicValues', async () => {
+            const result = await validateForman(
+                { name: '{{1.name}}' },
+                [{ name: 'name', type: 'text', mappable: false }],
+                { allowDynamicValues: true },
+            );
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: 'Value contains prohibited IML expression.' }),
+            ]);
+        });
+    });
+
+    describe('select with RPC options', () => {
+        const schema: FormanSchemaField[] = [{ name: 'color', type: 'select', options: 'rpc://getColors' }];
+        const resolveRemote = () =>
+            Promise.resolve([
+                { value: 'red', label: 'Red' },
+                { value: 'blue', label: 'Blue' },
+            ]);
+
+        it('should error when value not in RPC options and allowDynamicValues is false', async () => {
+            const result = await validateForman({ color: 'green' }, schema, { resolveRemote });
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: "Value 'green' not found in options." }),
+            ]);
+            expect(result.warnings).toEqual([]);
+        });
+
+        it('should warn (not error) when value not in RPC options and allowDynamicValues is true', async () => {
+            const result = await validateForman({ color: 'green' }, schema, {
+                resolveRemote,
+                allowDynamicValues: true,
+            });
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+            expect(result.warnings).toEqual([
+                expect.objectContaining({ message: "Value 'green' not found in options." }),
+            ]);
+        });
+
+        it('should produce mode:edit state only when allowDynamicValues is true', async () => {
+            const result = await validateForman({ color: 'green' }, schema, {
+                resolveRemote,
+                allowDynamicValues: true,
+                states: true,
+            });
+            expect(result.states).toEqual({
+                default: { color: { mode: 'edit' } },
+            });
+        });
+
+        it('should not produce mode:edit state when allowDynamicValues is false', async () => {
+            const result = await validateForman({ color: 'green' }, schema, {
+                resolveRemote,
+                states: true,
+            });
+            // Errors → no edit state
+            expect(result.valid).toBe(false);
+        });
+    });
+
+    describe('multiple select with RPC options', () => {
+        const schema: FormanSchemaField[] = [
+            { name: 'colors', type: 'select', multiple: true, options: 'rpc://getColors' },
+        ];
+        const resolveRemote = () => Promise.resolve([{ value: 'red', label: 'Red' }]);
+
+        it('should error for missing values when allowDynamicValues is false', async () => {
+            const result = await validateForman({ colors: ['red', 'green'] }, schema, { resolveRemote });
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: "Value 'green' not found in options." }),
+            ]);
+        });
+
+        it('should warn for missing values when allowDynamicValues is true', async () => {
+            const result = await validateForman({ colors: ['red', 'green'] }, schema, {
+                resolveRemote,
+                allowDynamicValues: true,
+            });
+            expect(result.valid).toBe(true);
+            expect(result.warnings).toEqual([
+                expect.objectContaining({ message: "Value 'green' not found in options." }),
+            ]);
+        });
+    });
+
+    describe('validateFormanWithDomains per-domain flag', () => {
+        const schema: FormanSchemaField[] = [{ name: 'field', type: 'text' }];
+
+        it('should allow IML in domain with allowDynamicValues and reject in domain without', async () => {
+            const result = await validateFormanWithDomains({
+                dynamic: {
+                    values: { field: '{{1.value}}' },
+                    schema,
+                    allowDynamicValues: true,
+                },
+                static: {
+                    values: { field: '{{1.value}}' },
+                    schema,
+                    allowDynamicValues: false,
+                },
+            });
+
+            expect(result.valid).toBe(false);
+            // Only the static domain should have the error
+            expect(result.errors).toEqual([
+                expect.objectContaining({
+                    domain: 'static',
+                    message: 'Value contains prohibited IML expression.',
+                }),
+            ]);
+        });
+    });
+});

--- a/test/directives/nested.spec.ts
+++ b/test/directives/nested.spec.ts
@@ -297,6 +297,7 @@ describe('Nested', () => {
 
             const result = await validateForman({ input: '{{2.value}}', dynamicallyRenderedField: 'aaa' }, schema, {
                 resolveRemote,
+                allowDynamicValues: true,
             });
             expect(result.valid).toBe(true);
             expect(result.errors).toEqual([]);
@@ -312,7 +313,10 @@ describe('Nested', () => {
                 },
             ];
 
-            const result = await validateForman({ input: '{{2.value}}' }, schema, { resolveRemote });
+            const result = await validateForman({ input: '{{2.value}}' }, schema, {
+                resolveRemote,
+                allowDynamicValues: true,
+            });
             expect(result.valid).toBe(false);
             expect(result.errors).toEqual([expect.objectContaining({ message: 'Field is mandatory.' })]);
         });
@@ -335,6 +339,7 @@ describe('Nested', () => {
 
             const result = await validateForman({ mySelect: '{{2.value}}', dynamicallyRenderedField: 'aaa' }, schema, {
                 resolveRemote,
+                allowDynamicValues: true,
             });
             expect(result.valid).toBe(true);
             expect(result.errors).toEqual([]);
@@ -353,7 +358,7 @@ describe('Nested', () => {
             const result = await validateForman(
                 { input: '{{2.value}}', dynamicallyRenderedField: 'aaa', unknownField: 'bad' },
                 schema,
-                { resolveRemote, strict: true },
+                { resolveRemote, strict: true, allowDynamicValues: true },
             );
             expect(result.valid).toBe(false);
             expect(result.errors).toEqual([

--- a/test/directives/rpc.spec.ts
+++ b/test/directives/rpc.spec.ts
@@ -444,6 +444,7 @@ describe('RPC', () => {
             },
         ];
         const result = await validateForman({ mySelect: 'missing' }, schema, {
+            allowDynamicValues: true,
             resolveRemote(): Promise<unknown> {
                 return Promise.resolve([
                     { value: 'a', label: 'Option A' },
@@ -474,6 +475,7 @@ describe('RPC', () => {
             },
         ];
         const result = await validateForman({ myMultiSelect: ['a', 'missing1', 'missing2'] }, schema, {
+            allowDynamicValues: true,
             resolveRemote(): Promise<unknown> {
                 return Promise.resolve([{ value: 'a', label: 'Option A' }]);
             },

--- a/test/restore.spec.ts
+++ b/test/restore.spec.ts
@@ -15,7 +15,7 @@ describe('Restore state for IML-mapped fields', () => {
                     ],
                 },
             ],
-            { states: true },
+            { states: true, allowDynamicValues: true },
         );
 
         expect(result).toEqual({
@@ -34,7 +34,7 @@ describe('Restore state for IML-mapped fields', () => {
         const result = await validateForman(
             { item: '{{1.item}}' },
             [{ name: 'item', type: 'select', options: { store: 'rpc://getItems' } }],
-            { states: true },
+            { states: true, allowDynamicValues: true },
         );
 
         expect(result).toEqual({
@@ -50,7 +50,10 @@ describe('Restore state for IML-mapped fields', () => {
     });
 
     it('should produce mode: edit for file field with IML value', async () => {
-        const result = await validateForman({ doc: '{{1.fileId}}' }, [{ name: 'doc', type: 'file' }], { states: true });
+        const result = await validateForman({ doc: '{{1.fileId}}' }, [{ name: 'doc', type: 'file' }], {
+            states: true,
+            allowDynamicValues: true,
+        });
 
         expect(result).toEqual({
             valid: true,
@@ -67,6 +70,7 @@ describe('Restore state for IML-mapped fields', () => {
     it('should produce mode: edit for folder field with IML value', async () => {
         const result = await validateForman({ dir: '{{1.folderId}}' }, [{ name: 'dir', type: 'folder' }], {
             states: true,
+            allowDynamicValues: true,
         });
 
         expect(result).toEqual({
@@ -84,6 +88,7 @@ describe('Restore state for IML-mapped fields', () => {
     it('should produce mode: edit for boolean field with IML value', async () => {
         const result = await validateForman({ flag: '{{1.isActive}}' }, [{ name: 'flag', type: 'boolean' }], {
             states: true,
+            allowDynamicValues: true,
         });
 
         expect(result).toEqual({
@@ -104,6 +109,7 @@ describe('Restore state for IML-mapped fields', () => {
             [{ name: 'item', type: 'select', options: 'rpc://getItems' }],
             {
                 states: true,
+                allowDynamicValues: true,
                 resolveRemote() {
                     return Promise.resolve([
                         { value: 'a', label: 'Option A' },
@@ -137,6 +143,7 @@ describe('Restore state for IML-mapped fields', () => {
             [{ name: 'items', type: 'select', multiple: true, options: 'rpc://getItems' }],
             {
                 states: true,
+                allowDynamicValues: true,
                 resolveRemote() {
                     return Promise.resolve([
                         { value: 'a', label: 'Option A' },

--- a/test/schemas.spec.ts
+++ b/test/schemas.spec.ts
@@ -86,7 +86,7 @@ describe('schemas output', () => {
                     nested: [{ name: 'sub', type: 'number', label: 'Sub' }],
                 },
             ],
-            { schemas: true },
+            { schemas: true, allowDynamicValues: true },
         );
 
         expect(result.valid).toBe(true);

--- a/test/validator-extended.spec.ts
+++ b/test/validator-extended.spec.ts
@@ -371,7 +371,7 @@ describe('Forman Schema Extended Validation', () => {
                 },
             ];
 
-            expect(await validateForman(formanValue, formanSchema)).toEqual({
+            expect(await validateForman(formanValue, formanSchema, { allowDynamicValues: true })).toEqual({
                 valid: false,
                 errors: [
                     {


### PR DESCRIPTION
## Summary

- Adds `allowDynamicValues` flag (default `false`) to control whether a domain permits IML expressions and unresolved RPC select values
- When `false`: IML expressions cause validation errors; values missing from RPC-loaded select options are treated as errors (same as static options)
- When `true`: preserves existing behavior — IML passes through, missing RPC values produce warnings + `mode:'edit'` state
- Available per-domain in `validateFormanWithDomains()` and via `FormanValidationOptions.allowDynamicValues` for `validateForman()`

This distinction is needed because trigger modules in Forman don't have a mappable `expect` domain — their fields can't use IML or switch to edit mode, so validation should reflect that.

## Changes

- **`src/types.ts`** — added `allowDynamicValues` to `FormanValidationOptions`
- **`src/index.ts`** — added `allowDynamicValues` to per-domain input type, propagated from `validateForman` options
- **`src/validator.ts`** — stored flag in `DomainRoot`, gated IML passthrough and RPC warning/edit-mode logic on it
- **`test/allow-dynamic-values.spec.ts`** — 10 new dedicated tests
- Updated existing tests to explicitly opt into dynamic behavior with `allowDynamicValues: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)