### PR TITLE
feat(validator): allow warnings for editable/mappable fields with RPC options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/forman-schema",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "license": "MIT",
             "devDependencies": {
                 "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "description": "Forman Schema Tools",
     "license": "MIT",
     "author": "Make",

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,8 @@ export type FormanSchemaField = {
     disabled?: boolean;
     /** Whether the field is mappable */
     mappable?: boolean;
+    /** Whether the field allows custom (typed-in) values even when dynamic values are not allowed in the domain */
+    editable?: boolean;
     /** Whether the user will be able to insert new lines in GUI (a textarea will be displayed instead of the text field) */
     multiline?: boolean;
     /** Whether the select field allows multiple values */

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -30,6 +30,11 @@ import {
 import { udttypeExpand } from './composites/udttype';
 import { udtspecExpand } from './composites/udtspec';
 
+/** Whether the field explicitly allows custom (typed-in) values */
+function fieldAllowsCustomValue(field: FormanSchemaField): boolean {
+    return field.mappable === true || field.editable === true;
+}
+
 /**
  * Context for schema validation operations
  */
@@ -884,7 +889,10 @@ async function handlePathType(value: unknown, field: FormanSchemaField, context:
 
         const selectedOption = selectableOptions.find(candidate => candidate.value === levelSelectedValue);
         if (!selectedOption) {
-            if (optionsFromRPC) {
+            if (
+                optionsFromRPC &&
+                (context.roots[context.domain]!.allowDynamicValues || fieldAllowsCustomValue(field))
+            ) {
                 warnings.push({
                     domain: context.domain,
                     path: context.path.join('.'),
@@ -1012,7 +1020,10 @@ async function handleSelectType(
                 optionsOrGroups as FormanSchemaSelectOptionsStore,
             );
             if (!found) {
-                (optionsFromRPC && context.roots[context.domain]!.allowDynamicValues ? warnings : errors).push({
+                (optionsFromRPC && (context.roots[context.domain]!.allowDynamicValues || fieldAllowsCustomValue(field))
+                    ? warnings
+                    : errors
+                ).push({
                     domain: context.domain,
                     path: context.path.join('.'),
                     message: `Value '${singleValue}' not found in options.`,
@@ -1021,7 +1032,11 @@ async function handleSelectType(
             }
         }
 
-        if (optionsFromRPC && context.roots[context.domain]!.allowDynamicValues && hasUnresolvedValue) {
+        if (
+            optionsFromRPC &&
+            (context.roots[context.domain]!.allowDynamicValues || fieldAllowsCustomValue(field)) &&
+            hasUnresolvedValue
+        ) {
             context.roots[context.domain]!.fieldStates.push({
                 path: context.path,
                 state: { mode: 'edit' },
@@ -1067,7 +1082,10 @@ async function handleSelectType(
         const item = findValueInSelectOptions(field, value, optionsOrGroups as FormanSchemaSelectOptionsStore);
 
         if (!item) {
-            if (optionsFromRPC && context.roots[context.domain]!.allowDynamicValues) {
+            if (
+                optionsFromRPC &&
+                (context.roots[context.domain]!.allowDynamicValues || fieldAllowsCustomValue(field))
+            ) {
                 warnings.push({
                     domain: context.domain,
                     path: context.path.join('.'),

--- a/test/allow-dynamic-values.spec.ts
+++ b/test/allow-dynamic-values.spec.ts
@@ -136,4 +136,118 @@ describe('allowDynamicValues', () => {
             ]);
         });
     });
+
+    describe('editable/mappable field overrides allowDynamicValues for RPC options', () => {
+        const resolveRemote = () =>
+            Promise.resolve([
+                { value: 'red', label: 'Red' },
+                { value: 'blue', label: 'Blue' },
+            ]);
+
+        describe('select with RPC', () => {
+            it('should warn when field has editable: true even if allowDynamicValues is false', async () => {
+                const schema: FormanSchemaField[] = [
+                    { name: 'color', type: 'select', options: 'rpc://getColors', editable: true },
+                ];
+                const result = await validateForman({ color: 'green' }, schema, { resolveRemote });
+                expect(result.valid).toBe(true);
+                expect(result.errors).toEqual([]);
+                expect(result.warnings).toEqual([
+                    expect.objectContaining({ message: "Value 'green' not found in options." }),
+                ]);
+            });
+
+            it('should warn when field has mappable: true even if allowDynamicValues is false', async () => {
+                const schema: FormanSchemaField[] = [
+                    { name: 'color', type: 'select', options: 'rpc://getColors', mappable: true },
+                ];
+                const result = await validateForman({ color: 'green' }, schema, { resolveRemote });
+                expect(result.valid).toBe(true);
+                expect(result.errors).toEqual([]);
+                expect(result.warnings).toEqual([
+                    expect.objectContaining({ message: "Value 'green' not found in options." }),
+                ]);
+            });
+
+            it('should produce mode:edit state when field has editable: true', async () => {
+                const schema: FormanSchemaField[] = [
+                    { name: 'color', type: 'select', options: 'rpc://getColors', editable: true },
+                ];
+                const result = await validateForman({ color: 'green' }, schema, {
+                    resolveRemote,
+                    states: true,
+                });
+                expect(result.states).toEqual({
+                    default: { color: { mode: 'edit' } },
+                });
+            });
+
+            it('should still error when field has no editable/mappable flags and allowDynamicValues is false', async () => {
+                const schema: FormanSchemaField[] = [{ name: 'color', type: 'select', options: 'rpc://getColors' }];
+                const result = await validateForman({ color: 'green' }, schema, { resolveRemote });
+                expect(result.valid).toBe(false);
+                expect(result.errors).toEqual([
+                    expect.objectContaining({ message: "Value 'green' not found in options." }),
+                ]);
+            });
+        });
+
+        describe('multiple select with RPC', () => {
+            it('should warn when field has editable: true even if allowDynamicValues is false', async () => {
+                const schema: FormanSchemaField[] = [
+                    { name: 'colors', type: 'select', multiple: true, options: 'rpc://getColors', editable: true },
+                ];
+                const result = await validateForman({ colors: ['red', 'green'] }, schema, { resolveRemote });
+                expect(result.valid).toBe(true);
+                expect(result.warnings).toEqual([
+                    expect.objectContaining({ message: "Value 'green' not found in options." }),
+                ]);
+            });
+        });
+
+        describe('path with RPC', () => {
+            const resolveRemotePath = () =>
+                Promise.resolve([
+                    { value: '', label: 'Root', children: true },
+                    { value: 'folder1', label: 'Folder 1' },
+                ]);
+
+            it('should warn when field has editable: true even if allowDynamicValues is false', async () => {
+                const schema: FormanSchemaField[] = [
+                    { name: 'path', type: 'folder', options: 'rpc://getFolders', editable: true },
+                ];
+                const result = await validateForman({ path: '/unknown' }, schema, {
+                    resolveRemote: resolveRemotePath,
+                });
+                expect(result.valid).toBe(true);
+                expect(result.errors).toEqual([]);
+                expect(result.warnings).toEqual([
+                    expect.objectContaining({ message: "Path 'unknown' not found in options." }),
+                ]);
+            });
+
+            it('should error when field has no editable/mappable flags and allowDynamicValues is false', async () => {
+                const schema: FormanSchemaField[] = [{ name: 'path', type: 'folder', options: 'rpc://getFolders' }];
+                const result = await validateForman({ path: '/unknown' }, schema, {
+                    resolveRemote: resolveRemotePath,
+                });
+                expect(result.valid).toBe(false);
+                expect(result.errors).toEqual([
+                    expect.objectContaining({ message: "Path 'unknown' not found in options." }),
+                ]);
+            });
+        });
+
+        describe('IML is NOT affected by editable flag', () => {
+            it('should still reject IML when editable: true but allowDynamicValues is false', async () => {
+                const result = await validateForman({ name: '{{1.name}}' }, [
+                    { name: 'name', type: 'text', editable: true },
+                ]);
+                expect(result.valid).toBe(false);
+                expect(result.errors).toEqual([
+                    expect.objectContaining({ message: 'Value contains prohibited IML expression.' }),
+                ]);
+            });
+        });
+    });
 });

--- a/test/validator-extended.spec.ts
+++ b/test/validator-extended.spec.ts
@@ -1591,11 +1591,13 @@ describe('Forman Schema Extended Validation', () => {
                     name: 'validPath',
                     type: 'file',
                     options: 'rpc://file-tree',
+                    editable: true,
                 },
                 {
                     name: 'invalidPath',
                     type: 'file',
                     options: 'rpc://file-tree',
+                    editable: true,
                 },
             ];
 
@@ -1750,6 +1752,7 @@ describe('Forman Schema Extended Validation', () => {
                     name: 'pathThroughFile',
                     type: 'folder',
                     options: 'rpc://file-tree',
+                    editable: true,
                 },
             ];
 


### PR DESCRIPTION
## Summary

- Adds `editable?: boolean` property to `FormanSchemaField` type
- When a select or path field with RPC options has `editable: true` or `mappable: true`, a value not found in RPC options now produces a **warning** (+ `mode: 'edit'` state) instead of an error — even when the domain has `allowDynamicValues: false`
- IML expression validation is **unaffected** — still depends only on `allowDynamicValues`
- Path fields with RPC now require explicit opt-in (`allowDynamicValues`, `editable`, or `mappable`) to produce warnings instead of errors (previously always warned on RPC)

## Motivation

Trigger modules may have fields in unmappable parameter domains (`allowDynamicValues: false`) that still need to allow manually typed custom values in a dynamic dropdown. The `editable` flag enables this without opening up IML support for the entire domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)