### PR TITLE
feat(types): adding list, radio, and fetch options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.12.1",
+    "version": "1.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/forman-schema",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "license": "MIT",
             "devDependencies": {
                 "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.12.1",
+    "version": "1.13.0",
     "description": "Forman Schema Tools",
     "license": "MIT",
     "author": "Make",

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -121,6 +121,7 @@ const FORMAN_TYPE_MAP: Readonly<Record<string, JSONSchema7['type']>> = {
     path: 'string',
     pkey: 'string',
     port: 'number',
+    list: 'string',
     radio: 'string',
     select: 'string',
     udttype: 'string',
@@ -267,6 +268,7 @@ export function toJSONSchemaInternal(field: FormanSchemaField, context: Conversi
             return handleCollectionType(normalizedField, result, context);
         case 'array':
             return handleArrayType(normalizedField, result, context);
+        case 'list':
         case 'radio':
         case 'select':
         case 'account':

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -575,7 +575,18 @@ function handleSelectOrPathType(
                 {} as Record<string, unknown>,
             );
             // Special treatment for select-like fields which are supposed to be displayed differently, like 'radio' or 'list'
-            if (![...FORMAN_REFERENCE_TYPES, 'select'].includes(field.type)) xFetchOptions['type'] = field.type;
+            if (
+                ![
+                    // Reference Types are distinguished by the Loader Tool Name directly
+                    ...FORMAN_REFERENCE_TYPES,
+                    // Select is default
+                    'select',
+                    // File and Folder are distinguished by the x-path metadata, so we don't need to append it here
+                    'file',
+                    'folder',
+                ].includes(field.type)
+            )
+                xFetchOptions['type'] = field.type;
             if (Object.keys(xFetchOptions).length) {
                 Object.defineProperty(result, 'x-fetch-options', {
                     configurable: true,

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -565,37 +565,34 @@ function handleSelectOrPathType(
         });
 
         // Additional fetching options, if provided
+        const xFetchOptions: Record<string, unknown> = {};
         if (isObject<FormanSchemaExtendedOptions>(field.options)) {
-            const xFetchOptions = (['label', 'value'] as const).reduce(
-                (transferObject, transferKey) => {
-                    const transferValue = (field.options as FormanSchemaExtendedOptions)[transferKey];
-                    if (transferValue) transferObject[transferKey] = transferValue;
-                    return transferObject;
-                },
-                {} as Record<string, unknown>,
-            );
-            // Special treatment for select-like fields which are supposed to be displayed differently, like 'radio' or 'list'
-            if (
-                ![
-                    // Reference Types are distinguished by the Loader Tool Name directly
-                    ...FORMAN_REFERENCE_TYPES,
-                    // Select is default
-                    'select',
-                    // File and Folder are distinguished by the x-path metadata, so we don't need to append it here
-                    'file',
-                    'folder',
-                ].includes(field.type)
-            ) {
-                xFetchOptions['type'] = field.type;
+            for (const transferKey of ['label', 'value'] as const) {
+                const transferValue = field.options[transferKey];
+                if (transferValue) xFetchOptions[transferKey] = transferValue;
             }
-            if (Object.keys(xFetchOptions).length) {
-                Object.defineProperty(result, 'x-fetch-options', {
-                    configurable: true,
-                    enumerable: true,
-                    writable: true,
-                    value: xFetchOptions,
-                });
-            }
+        }
+        // Special treatment for select-like fields which are supposed to be displayed differently, like 'radio' or 'list'
+        if (
+            ![
+                // Reference Types are distinguished by the Loader Tool Name directly
+                ...FORMAN_REFERENCE_TYPES,
+                // Select is default
+                'select',
+                // File and Folder are distinguished by the x-path metadata, so we don't need to append it here
+                'file',
+                'folder',
+            ].includes(field.type)
+        ) {
+            xFetchOptions['type'] = field.type;
+        }
+        if (Object.keys(xFetchOptions).length) {
+            Object.defineProperty(result, 'x-fetch-options', {
+                configurable: true,
+                enumerable: true,
+                writable: true,
+                value: xFetchOptions,
+            });
         }
     } else {
         let options = optionsOrGroups?.flatMap(optionOrGroup => {

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -562,6 +562,28 @@ function handleSelectOrPathType(
             writable: true,
             value: appendQueryString(optionsOrGroups, context.domain, context.tail),
         });
+
+        // Additional fetching options, if provided
+        if (isObject<FormanSchemaExtendedOptions>(field.options)) {
+            const xFetchOptions = (['label', 'value'] as const).reduce(
+                (transferObject, transferKey) => {
+                    const transferValue = (field.options as FormanSchemaExtendedOptions)[transferKey];
+                    if (transferValue) transferObject[transferKey] = transferValue;
+                    return transferObject;
+                },
+                {} as Record<string, unknown>,
+            );
+            // For non-selects, the type is required to properly handle the fetched options displaying
+            if (field.type !== 'select') xFetchOptions['type'] = field.type;
+            if (Object.keys(xFetchOptions).length) {
+                Object.defineProperty(result, 'x-fetch-options', {
+                    configurable: true,
+                    enumerable: true,
+                    writable: true,
+                    value: xFetchOptions,
+                });
+            }
+        }
     } else {
         let options = optionsOrGroups?.flatMap(optionOrGroup => {
             // Selects can be partially grouped, unwrap the groups, and append the rest.

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -585,8 +585,9 @@ function handleSelectOrPathType(
                     'file',
                     'folder',
                 ].includes(field.type)
-            )
+            ) {
                 xFetchOptions['type'] = field.type;
+            }
             if (Object.keys(xFetchOptions).length) {
                 Object.defineProperty(result, 'x-fetch-options', {
                     configurable: true,

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -121,6 +121,7 @@ const FORMAN_TYPE_MAP: Readonly<Record<string, JSONSchema7['type']>> = {
     path: 'string',
     pkey: 'string',
     port: 'number',
+    radio: 'string',
     select: 'string',
     udttype: 'string',
     udtspec: 'array',
@@ -266,6 +267,7 @@ export function toJSONSchemaInternal(field: FormanSchemaField, context: Conversi
             return handleCollectionType(normalizedField, result, context);
         case 'array':
             return handleArrayType(normalizedField, result, context);
+        case 'radio':
         case 'select':
         case 'account':
         case 'hook':

--- a/src/forman.ts
+++ b/src/forman.ts
@@ -17,6 +17,7 @@ import {
     IML_UNARY_FILTER_OPERATORS,
     IML_BINARY_FILTER_OPERATORS,
     IML_FILTER_ENTRY_TYPES,
+    FORMAN_REFERENCE_TYPES,
 } from './utils';
 import { udttypeExpand, udttypeExtractInner, udttypeWrapRef } from './composites/udttype';
 import { udtspecExpand, udtspecExtractInner, udtspecWrapRef } from './composites/udtspec';
@@ -573,8 +574,8 @@ function handleSelectOrPathType(
                 },
                 {} as Record<string, unknown>,
             );
-            // For non-selects, the type is required to properly handle the fetched options displaying
-            if (field.type !== 'select') xFetchOptions['type'] = field.type;
+            // Special treatment for select-like fields which are supposed to be displayed differently, like 'radio' or 'list'
+            if (![...FORMAN_REFERENCE_TYPES, 'select'].includes(field.type)) xFetchOptions['type'] = field.type;
             if (Object.keys(xFetchOptions).length) {
                 Object.defineProperty(result, 'x-fetch-options', {
                     configurable: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type FormanSchemaFieldType =
     | 'path'
     | 'pkey'
     | 'port'
+    | 'list'
     | 'radio'
     | 'select'
     | 'time'

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type FormanSchemaFieldType =
     | 'path'
     | 'pkey'
     | 'port'
+    | 'radio'
     | 'select'
     | 'time'
     | 'timestamp'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,6 +145,13 @@ export function normalizeFormanFieldType(field: FormanSchemaField): FormanSchema
     };
 }
 
+function valuesMatch(a: unknown, b: unknown): boolean {
+    if (a === b) return true;
+    // If this ever turns out insufficient, move to object-hash, but given the fact Forman sets the Form Value based on the RPC, which is the data source for the BE validation as well, the stringification should be sufficient.
+    if (isObject(a) && isObject(b)) return JSON.stringify(a) === JSON.stringify(b);
+    return false;
+}
+
 /**
  * Finds an option in the provided options and groups based on the given value.
  * Handles also the case of partially grouped selects, where some options can be on the top-level and some can be inside groups.
@@ -158,14 +165,19 @@ export function findValueInSelectOptions(
     optionsAndGroups?: FormanSchemaSelectOptionsStore,
 ): FormanSchemaOption | undefined {
     if (!optionsAndGroups) return undefined;
+
+    const valueKey =
+        isObject<FormanSchemaExtendedOptions>(field.options) && field.options.value ? field.options.value : 'value';
+
+    const matches = (option: FormanSchemaOption | FormanSchemaOptionGroup) =>
+        valuesMatch((option as Record<string, unknown>)[valueKey], value);
+
     if (field.grouped) {
-        const found = optionsAndGroups
-            .flatMap(group => ('options' in group ? group.options : []))
-            .find(option => option.value === value);
+        const found = optionsAndGroups.flatMap(group => ('options' in group ? group.options : [])).find(matches);
         if (found) return found;
     }
     // The thing is, that Forman supports "partially-grouped" selects, so in case value is not found in the groups, it can still be sitting on the top-level.
-    const found = optionsAndGroups.find(option => 'value' in option && option.value === value);
+    const found = optionsAndGroups.find(option => valueKey in option && matches(option));
     return found as FormanSchemaOption | undefined; // If there was a value, then it has to be an option, because option groups don't have values
 }
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -194,6 +194,7 @@ const FORMAN_TYPE_MAP: Readonly<Record<string, string | undefined>> = {
     path: 'string',
     pkey: 'string',
     port: 'number',
+    list: undefined,
     radio: undefined,
     select: undefined,
     udttype: 'string',
@@ -473,6 +474,7 @@ async function validateFormanValue(
             return handleCollectionType(value as Record<string, unknown>, normalizedField, context);
         case 'array':
             return handleArrayType(value as unknown[], normalizedField, context);
+        case 'list':
         case 'radio':
         case 'select':
         case 'account':

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -194,6 +194,7 @@ const FORMAN_TYPE_MAP: Readonly<Record<string, string | undefined>> = {
     path: 'string',
     pkey: 'string',
     port: 'number',
+    radio: undefined,
     select: undefined,
     udttype: 'string',
     udtspec: 'array',
@@ -472,6 +473,7 @@ async function validateFormanValue(
             return handleCollectionType(value as Record<string, unknown>, normalizedField, context);
         case 'array':
             return handleArrayType(value as unknown[], normalizedField, context);
+        case 'radio':
         case 'select':
         case 'account':
         case 'hook':

--- a/test/list.spec.ts
+++ b/test/list.spec.ts
@@ -90,15 +90,15 @@ describe('List type', () => {
         const resolveRemote = (path: string) => {
             if (path === 'rpc://items/list') {
                 return Promise.resolve([
-                    { value: 'item-1', label: 'Item 1' },
-                    { value: 'item-2', label: 'Item 2' },
+                    { data: { id: 1 }, label: 'Item 1' },
+                    { data: { id: 2 }, label: 'Item 2' },
                 ]);
             }
             return Promise.resolve([]);
         };
 
         it('should validate list with valid RPC value', async () => {
-            const result = await validateForman({ item: 'item-1' }, listSchema, { resolveRemote });
+            const result = await validateForman({ item: { id: 1 } }, listSchema, { resolveRemote });
             expect(result.valid).toBe(true);
             expect(result.errors).toEqual([]);
         });

--- a/test/list.spec.ts
+++ b/test/list.spec.ts
@@ -98,6 +98,44 @@ describe('List type', () => {
             expect(choice['x-fetch-options']).toBeUndefined();
         });
 
+        it('should emit x-fetch-options with type when list options is a string shorthand', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'item',
+                        type: 'list',
+                        required: true,
+                        options: 'rpc://items/list',
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const item = props.item as Record<string, unknown>;
+            expect(item['x-fetch']).toBe('rpc://items/list');
+            expect(item['x-fetch-options']).toEqual({ type: 'list' });
+        });
+
+        it('should not emit x-fetch-options when select options is a string shorthand', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'choice',
+                        type: 'select',
+                        required: true,
+                        options: 'rpc://items/list',
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const choice = props.choice as Record<string, unknown>;
+            expect(choice['x-fetch']).toBe('rpc://items/list');
+            expect(choice['x-fetch-options']).toBeUndefined();
+        });
+
         it('should produce x-fetch-options on nested list inside a select option', () => {
             const result = toJSONSchema({
                 type: 'collection',

--- a/test/list.spec.ts
+++ b/test/list.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from '@jest/globals';
+import { toJSONSchema, validateForman } from '../src/index.js';
+import type { FormanSchemaField } from '../src/index.js';
+
+const listSchema: FormanSchemaField[] = [
+    {
+        name: 'item',
+        type: 'list',
+        required: true,
+        options: {
+            store: 'rpc://items/list',
+            value: 'data',
+        },
+    },
+];
+
+describe('List type', () => {
+    describe('toJSONSchema', () => {
+        it('should convert list with RPC options to JSON Schema with x-fetch', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: listSchema,
+            });
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    type: 'object',
+                    required: ['item'],
+                }),
+            );
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const item = props.item as Record<string, unknown>;
+            expect(item.type).toBe('string');
+            expect(item['x-fetch']).toBe('rpc://items/list');
+        });
+
+        it('should convert list with inline options to oneOf', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'pick',
+                        type: 'list',
+                        required: true,
+                        options: [
+                            { label: 'First', value: 'first' },
+                            { label: 'Second', value: 'second' },
+                        ],
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const pick = props.pick as Record<string, unknown>;
+            expect(pick.type).toBe('string');
+            expect(pick.oneOf).toEqual([
+                { title: 'First', const: 'first' },
+                { title: 'Second', const: 'second' },
+            ]);
+        });
+
+        it('should convert non-required list with empty default', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'pick',
+                        type: 'list',
+                        options: [
+                            { label: 'A', value: 'a' },
+                            { label: 'B', value: 'b' },
+                        ],
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const pick = props.pick as Record<string, unknown>;
+            expect(pick.default).toBe('');
+            expect(pick.oneOf).toEqual([
+                { title: 'Empty', const: '' },
+                { title: 'A', const: 'a' },
+                { title: 'B', const: 'b' },
+            ]);
+        });
+    });
+
+    describe('validateForman', () => {
+        const resolveRemote = (path: string) => {
+            if (path === 'rpc://items/list') {
+                return Promise.resolve([
+                    { value: 'item-1', label: 'Item 1' },
+                    { value: 'item-2', label: 'Item 2' },
+                ]);
+            }
+            return Promise.resolve([]);
+        };
+
+        it('should validate list with valid RPC value', async () => {
+            const result = await validateForman({ item: 'item-1' }, listSchema, { resolveRemote });
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+
+        it('should reject invalid list value', async () => {
+            const result = await validateForman({ item: 'invalid' }, listSchema, { resolveRemote });
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: "Value 'invalid' not found in options." }),
+            ]);
+        });
+
+        it('should validate list with inline options', async () => {
+            const schema: FormanSchemaField[] = [
+                {
+                    name: 'pick',
+                    type: 'list',
+                    required: true,
+                    options: [
+                        { label: 'First', value: 'first' },
+                        { label: 'Second', value: 'second' },
+                    ],
+                },
+            ];
+            const result = await validateForman({ pick: 'first' }, schema);
+            expect(result.valid).toBe(true);
+        });
+    });
+});

--- a/test/list.spec.ts
+++ b/test/list.spec.ts
@@ -16,7 +16,7 @@ const listSchema: FormanSchemaField[] = [
 
 describe('List type', () => {
     describe('toJSONSchema', () => {
-        it('should convert list with RPC options to JSON Schema with x-fetch', () => {
+        it('should convert list with RPC options to JSON Schema with x-fetch and x-fetch-options', () => {
             const result = toJSONSchema({
                 type: 'collection',
                 spec: listSchema,
@@ -33,6 +33,112 @@ describe('List type', () => {
             const item = props.item as Record<string, unknown>;
             expect(item.type).toBe('string');
             expect(item['x-fetch']).toBe('rpc://items/list');
+            expect(item['x-fetch-options']).toEqual({ value: 'data', type: 'list' });
+        });
+
+        it('should include label and value in x-fetch-options when both are specified', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'item',
+                        type: 'list',
+                        required: true,
+                        options: {
+                            store: 'rpc://items/list',
+                            label: 'name',
+                            value: 'data',
+                        },
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const item = props.item as Record<string, unknown>;
+            expect(item['x-fetch-options']).toEqual({ label: 'name', value: 'data', type: 'list' });
+        });
+
+        it('should include type in x-fetch-options for list even without label/value', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'item',
+                        type: 'list',
+                        required: true,
+                        options: {
+                            store: 'rpc://items/list',
+                        },
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const item = props.item as Record<string, unknown>;
+            expect(item['x-fetch-options']).toEqual({ type: 'list' });
+        });
+
+        it('should not include x-fetch-options for select type without label/value', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'choice',
+                        type: 'select',
+                        required: true,
+                        options: {
+                            store: 'rpc://items/list',
+                        },
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const choice = props.choice as Record<string, unknown>;
+            expect(choice['x-fetch-options']).toBeUndefined();
+        });
+
+        it('should produce x-fetch-options on nested list inside a select option', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: '__type',
+                        type: 'select',
+                        required: true,
+                        options: [
+                            {
+                                value: 'select',
+                                label: 'Start from a specific item',
+                                nested: [
+                                    {
+                                        name: 'select',
+                                        label: 'Starting item',
+                                        type: 'list',
+                                        required: true,
+                                        options: {
+                                            store: 'rpc://test@1/epoch:test',
+                                            value: 'data',
+                                        },
+                                    },
+                                ],
+                            },
+                            {
+                                value: 'all',
+                                label: 'All items',
+                            },
+                        ],
+                    },
+                ],
+            });
+
+            const allOf = (result as Record<string, unknown>).allOf as Record<string, unknown>[];
+            expect(allOf).toHaveLength(1);
+
+            const then = allOf[0]!.then as Record<string, unknown>;
+            const selectProp = (then.properties as Record<string, unknown>).select as Record<string, unknown>;
+            expect(selectProp['x-fetch']).toBe('rpc://test@1/epoch:test?__type={{__type}}');
+            expect(selectProp['x-fetch-options']).toEqual({ value: 'data', type: 'list' });
         });
 
         it('should convert list with inline options to oneOf', () => {

--- a/test/radio.spec.ts
+++ b/test/radio.spec.ts
@@ -88,6 +88,25 @@ describe('Radio type', () => {
             );
         });
 
+        it('should emit x-fetch-options with type when radio options is a string shorthand', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'mode',
+                        type: 'radio',
+                        required: true,
+                        options: 'rpc://modes/list',
+                    },
+                ],
+            });
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const mode = props.mode as Record<string, unknown>;
+            expect(mode['x-fetch']).toBe('rpc://modes/list');
+            expect(mode['x-fetch-options']).toEqual({ type: 'radio' });
+        });
+
         it('should convert non-required radio with empty default', () => {
             const result = toJSONSchema({
                 type: 'collection',

--- a/test/radio.spec.ts
+++ b/test/radio.spec.ts
@@ -126,17 +126,19 @@ describe('Radio type', () => {
         const resolveRemote = (path: string) => {
             if (path === 'rpc://email/7.5.10/RpcTriggerNewEmailEpoch') {
                 return Promise.resolve([
-                    { value: 'email-1', label: 'Email 1' },
-                    { value: 'email-2', label: 'Email 2' },
+                    { data: { lastId: 1, epochType: 'select' }, label: 'Email 1' },
+                    { data: { lastId: 2, epochType: 'select' }, label: 'Email 2' },
                 ]);
             }
             return Promise.resolve([]);
         };
 
         it('should validate radio with valid value and nested fields', async () => {
-            const result = await validateForman({ __type: 'select', select: 'email-1' }, radioSchema, {
-                resolveRemote,
-            });
+            const result = await validateForman(
+                { __type: 'select', select: { lastId: 1, epochType: 'select' } },
+                radioSchema,
+                { resolveRemote },
+            );
             expect(result.valid).toBe(true);
             expect(result.errors).toEqual([]);
         });

--- a/test/radio.spec.ts
+++ b/test/radio.spec.ts
@@ -15,7 +15,7 @@ const radioSchema: FormanSchemaField[] = [
                     {
                         name: 'select',
                         label: '',
-                        type: 'select',
+                        type: 'list',
                         required: true,
                         options: {
                             store: 'rpc://email/7.5.10/RpcTriggerNewEmailEpoch',

--- a/test/radio.spec.ts
+++ b/test/radio.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from '@jest/globals';
+import { toJSONSchema, validateForman } from '../src/index.js';
+import type { FormanSchemaField } from '../src/index.js';
+
+const radioSchema: FormanSchemaField[] = [
+    {
+        name: '__type',
+        type: 'radio',
+        required: true,
+        options: [
+            {
+                label: 'Select the first email',
+                value: 'select',
+                nested: [
+                    {
+                        name: 'select',
+                        label: '',
+                        type: 'select',
+                        required: true,
+                        options: {
+                            store: 'rpc://email/7.5.10/RpcTriggerNewEmailEpoch',
+                            value: 'data',
+                        },
+                    },
+                ],
+            },
+            {
+                label: 'Emails from after a specific date',
+                value: 'date',
+                nested: [
+                    {
+                        name: 'date',
+                        type: 'date',
+                        time: true,
+                        label: '',
+                        required: true,
+                    },
+                ],
+            },
+            {
+                label: 'All emails',
+                value: 'all',
+            },
+            {
+                label: 'From now on',
+                value: 'now',
+            },
+        ],
+    },
+];
+
+describe('Radio type', () => {
+    describe('toJSONSchema', () => {
+        it('should convert radio to JSON Schema with oneOf and allOf conditionals', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: radioSchema,
+            });
+
+            expect(result).toEqual(
+                expect.objectContaining({
+                    type: 'object',
+                    required: ['__type'],
+                }),
+            );
+
+            const props = (result as Record<string, unknown> & { properties: Record<string, unknown> }).properties;
+            const __type = props.__type as Record<string, unknown>;
+            expect(__type.type).toBe('string');
+            expect(__type.oneOf).toEqual([
+                { title: 'Select the first email', const: 'select' },
+                { title: 'Emails from after a specific date', const: 'date' },
+                { title: 'All emails', const: 'all' },
+                { title: 'From now on', const: 'now' },
+            ]);
+
+            const allOf = (result as Record<string, unknown>).allOf as Record<string, unknown>[];
+            expect(allOf).toHaveLength(2);
+            expect(allOf[0]).toEqual(
+                expect.objectContaining({
+                    if: { properties: { __type: { const: 'select' } } },
+                }),
+            );
+            expect(allOf[1]).toEqual(
+                expect.objectContaining({
+                    if: { properties: { __type: { const: 'date' } } },
+                }),
+            );
+        });
+
+        it('should convert non-required radio with empty default', () => {
+            const result = toJSONSchema({
+                type: 'collection',
+                spec: [
+                    {
+                        name: 'choice',
+                        type: 'radio',
+                        options: [
+                            { label: 'A', value: 'a' },
+                            { label: 'B', value: 'b' },
+                        ],
+                    },
+                ],
+            });
+
+            expect(result).toEqual({
+                type: 'object',
+                properties: {
+                    choice: {
+                        type: 'string',
+                        default: '',
+                        description: expect.any(String),
+                        oneOf: [
+                            { title: 'Empty', const: '' },
+                            { title: 'A', const: 'a' },
+                            { title: 'B', const: 'b' },
+                        ],
+                    },
+                },
+                required: [],
+            });
+        });
+    });
+
+    describe('validateForman', () => {
+        const resolveRemote = (path: string) => {
+            if (path === 'rpc://email/7.5.10/RpcTriggerNewEmailEpoch') {
+                return Promise.resolve([
+                    { value: 'email-1', label: 'Email 1' },
+                    { value: 'email-2', label: 'Email 2' },
+                ]);
+            }
+            return Promise.resolve([]);
+        };
+
+        it('should validate radio with valid value and nested fields', async () => {
+            const result = await validateForman({ __type: 'select', select: 'email-1' }, radioSchema, {
+                resolveRemote,
+            });
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+
+        it('should validate radio with value that has no nested', async () => {
+            const result = await validateForman({ __type: 'all' }, radioSchema, { resolveRemote });
+            expect(result.valid).toBe(true);
+            expect(result.errors).toEqual([]);
+        });
+
+        it('should reject invalid radio value', async () => {
+            const result = await validateForman({ __type: 'invalid' }, radioSchema, { resolveRemote });
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: "Value 'invalid' not found in options." }),
+            ]);
+        });
+
+        it('should reject missing required nested field', async () => {
+            const result = await validateForman({ __type: 'date' }, radioSchema, { resolveRemote });
+            expect(result.valid).toBe(false);
+            expect(result.errors).toEqual([
+                expect.objectContaining({ message: 'Field is mandatory.' }),
+            ]);
+        });
+    });
+});

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -297,9 +297,6 @@ describe('Forman Schema', () => {
                     default: '',
                     description: 'Optional field, can be left empty.',
                     'x-fetch': 'rpc://get-folders',
-                    'x-fetch-options': {
-                        type: 'folder',
-                    },
                     'x-path': {
                         ownName: 'folder',
                         showRoot: false,

--- a/test/test.spec.ts
+++ b/test/test.spec.ts
@@ -297,6 +297,9 @@ describe('Forman Schema', () => {
                     default: '',
                     description: 'Optional field, can be left empty.',
                     'x-fetch': 'rpc://get-folders',
+                    'x-fetch-options': {
+                        type: 'folder',
+                    },
                     'x-path': {
                         ownName: 'folder',
                         showRoot: false,

--- a/test/validator-extended.spec.ts
+++ b/test/validator-extended.spec.ts
@@ -2166,7 +2166,7 @@ describe('Forman Schema Extended Validation', () => {
     describe('Extended options with custom value key', () => {
         const rpcOptions = [
             {
-                label: '<test@mail.com> - DZIZS (10.04.2026)',
+                label: '<test@mail.com> - MAYO (10.04.2026)',
                 date: '2026-04-10T11:40:11.000Z',
                 data: {
                     lastDate: '2026-04-10T11:40:11.000Z',

--- a/test/validator-extended.spec.ts
+++ b/test/validator-extended.spec.ts
@@ -2162,4 +2162,166 @@ describe('Forman Schema Extended Validation', () => {
             });
         });
     });
+
+    describe('Extended options with custom value key', () => {
+        const rpcOptions = [
+            {
+                label: '<test@mail.com> - DZIZS (10.04.2026)',
+                date: '2026-04-10T11:40:11.000Z',
+                data: {
+                    lastDate: '2026-04-10T11:40:11.000Z',
+                    lastId: 38,
+                    epochType: 'select',
+                },
+            },
+            {
+                label: '<test@mail.com> - TEST (10.04.2026)',
+                date: '2026-04-10T11:40:00.000Z',
+                data: {
+                    lastDate: '2026-04-10T11:40:00.000Z',
+                    lastId: 37,
+                    epochType: 'select',
+                },
+            },
+            {
+                label: '<test@mail.com> - HEYO (10.04.2026)',
+                date: '2026-04-10T11:39:46.000Z',
+                data: {
+                    lastDate: '2026-04-10T11:39:46.000Z',
+                    lastId: 36,
+                    epochType: 'select',
+                },
+            },
+        ];
+
+        const resolveRemote = async () => rpcOptions;
+
+        it('should validate list type with options.value pointing to a custom key', async () => {
+            const schema = [
+                {
+                    name: 'select',
+                    label: '',
+                    type: 'list',
+                    required: true,
+                    options: {
+                        store: 'rpc://test',
+                        value: 'data',
+                    },
+                },
+            ];
+
+            const result = await validateForman(
+                { select: { lastDate: '2026-04-10T11:40:11.000Z', lastId: 38, epochType: 'select' } },
+                schema,
+                { resolveRemote },
+            );
+
+            expect(result).toEqual({
+                valid: true,
+                errors: [],
+                warnings: [],
+            });
+        });
+
+        it('should reject invalid value with custom options.value key', async () => {
+            const schema = [
+                {
+                    name: 'select',
+                    label: '',
+                    type: 'list',
+                    required: true,
+                    options: {
+                        store: 'rpc://test',
+                        value: 'data',
+                    },
+                },
+            ];
+
+            const result = await validateForman({ select: { lastId: 999 } }, schema, { resolveRemote });
+
+            expect(result.valid).toBe(false);
+            expect(result.errors[0]!.message).toContain('not found in options');
+        });
+
+        it('should validate select type with options.value pointing to a custom key', async () => {
+            const schema = [
+                {
+                    name: 'choice',
+                    type: 'select',
+                    required: true,
+                    options: {
+                        store: 'rpc://test',
+                        value: 'date',
+                    },
+                },
+            ];
+
+            const result = await validateForman(
+                { choice: '2026-04-10T11:40:11.000Z' },
+                schema,
+                { resolveRemote },
+            );
+
+            expect(result).toEqual({
+                valid: true,
+                errors: [],
+                warnings: [],
+            });
+        });
+
+        it('should validate multiple select with custom options.value key', async () => {
+            const schema = [
+                {
+                    name: 'choices',
+                    type: 'select',
+                    required: true,
+                    multiple: true,
+                    options: {
+                        store: 'rpc://test',
+                        value: 'date',
+                    },
+                },
+            ];
+
+            const result = await validateForman(
+                { choices: ['2026-04-10T11:40:11.000Z', '2026-04-10T11:40:00.000Z'] },
+                schema,
+                { resolveRemote },
+            );
+
+            expect(result).toEqual({
+                valid: true,
+                errors: [],
+                warnings: [],
+            });
+        });
+
+        it('should use default value key when options.value is not specified', async () => {
+            const standardOptions = [
+                { value: 'a', label: 'Option A' },
+                { value: 'b', label: 'Option B' },
+            ];
+
+            const schema = [
+                {
+                    name: 'pick',
+                    type: 'select',
+                    required: true,
+                    options: {
+                        store: 'rpc://test',
+                    },
+                },
+            ];
+
+            const result = await validateForman({ pick: 'a' }, schema, {
+                resolveRemote: async () => standardOptions,
+            });
+
+            expect(result).toEqual({
+                valid: true,
+                errors: [],
+                warnings: [],
+            });
+        });
+    });
 });


### PR DESCRIPTION
I'm adding support for two types previously unknown to the Forman Schema:
- `list`
- `radio`

Also, I need to propagate a few additional information through `x-fetch-options` so the users of the generated schema know how to treat the fields.