### PR TITLE
fix(types): export validation options and result to allow better composition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/forman-schema",
-            "version": "1.13.1",
+            "version": "1.13.2",
             "license": "MIT",
             "devDependencies": {
                 "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.13.1",
+    "version": "1.13.2",
     "description": "Forman Schema Tools",
     "license": "MIT",
     "author": "Make",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export type {
     FormanSchemaExtendedNested,
     FormanSchemaOptionGroup,
     FormanSchemaRPCButton,
+    FormanValidationOptions,
+    FormanValidationResult,
 } from './types';
 export { toFormanSchema } from './json';
 


### PR DESCRIPTION
I'm just exposing two more types from Forman Validation so we can better compose types extenrally.