### PR TITLE
fix(validator): emit chosen option nested spec in field states

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -288,7 +288,12 @@ export type FormanSchemaFieldState = {
     path?: Array<string>;
     data?: Record<string, unknown>;
     extra?: Record<string, unknown>;
-    nested?: Record<string, FormanSchemaFieldState>;
+    /**
+     * Child field states (record, built from field paths) or, on `chose` states of
+     * select-like fields, the chosen option's nested field specification — the UI
+     * persists that spec in `metadata.restore` to render the dependent fields.
+     */
+    nested?: Record<string, FormanSchemaFieldState> | FormanSchemaNested;
     items?: Record<string, FormanSchemaFieldState>[];
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,7 +258,7 @@ export function buildRestoreStructure(
     items: Array<{
         domain: string;
         path: (string | number)[];
-        state: Omit<FormanSchemaFieldState, 'nested' | 'items'>;
+        state: Omit<FormanSchemaFieldState, 'items'>;
     }>,
 ): Record<string, FormanSchemaFieldState> {
     const result: Record<string, Record<string, FormanSchemaFieldState>> = {};
@@ -331,11 +331,16 @@ export function buildRestoreStructure(
                         }
                         current = current[key].items;
                     } else {
-                        // Next level is an object - navigate to nested
-                        if (!current[key].nested) {
+                        // Next level is an object - navigate to nested. A chose state may carry
+                        // the chosen option's nested spec here; child states take precedence.
+                        if (
+                            !current[key].nested ||
+                            typeof current[key].nested !== 'object' ||
+                            Array.isArray(current[key].nested)
+                        ) {
                             current[key].nested = {};
                         }
-                        current = current[key].nested;
+                        current = current[key].nested as Record<string, FormanSchemaFieldState>;
                     }
                 }
             }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -90,7 +90,7 @@ export interface DomainRoot {
         /** Path of the field (string for field name, number for array index) */
         path: (string | number)[];
         /** State of the field */
-        state: Omit<FormanSchemaFieldState, 'nested' | 'items'>;
+        state: Omit<FormanSchemaFieldState, 'items'>;
     }>;
     /** Resolved schema fields collected during validation */
     schemaFields: FormanSchemaField[];
@@ -1091,6 +1091,7 @@ async function handleSelectType(
                 state: {
                     mode: 'chose',
                     label: placeholder.label,
+                    ...(placeholder.nested ? { nested: placeholder.nested } : {}),
                 },
             });
         }
@@ -1135,6 +1136,7 @@ async function handleSelectType(
                     state: {
                         mode: isReferenceType(field.type) ? undefined : 'chose',
                         label: item.label,
+                        ...(item.nested ? { nested: item.nested } : {}),
                     },
                 });
             }

--- a/test/chosen-option-nested.spec.ts
+++ b/test/chosen-option-nested.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from '@jest/globals';
+import { validateForman } from '../src/index.js';
+
+/**
+ * The chosen option of a select-like field can carry the specification of its dependent
+ * fields in `option.nested`. The UI persists that spec in `metadata.restore` (as the
+ * `nested` member of the field's state) to render the dependent fields section. The
+ * generated field states must carry it, otherwise a restore rebuilt from states wipes
+ * the dependent fields from the form.
+ */
+describe('Chosen option nested spec in field states', () => {
+    const argumentsSpec = [
+        {
+            name: 'arguments',
+            type: 'collection',
+            label: 'Arguments',
+            spec: [
+                { name: 'url', type: 'text', label: 'URL' },
+                { name: 'method', type: 'text', label: 'Method' },
+            ],
+        },
+    ];
+
+    it('should emit the chosen RPC option nested spec on the field state', async () => {
+        const result = await validateForman(
+            { toolName: 'fetch-tool', arguments: { url: 'https://example.com', method: 'GET' } },
+            [{ name: 'toolName', type: 'select', options: 'rpc://listTools' }],
+            {
+                states: true,
+                resolveRemote() {
+                    return Promise.resolve([
+                        { value: 'fetch-tool', label: 'Fetch Tool', nested: argumentsSpec },
+                        { value: 'other-tool', label: 'Other Tool' },
+                    ]);
+                },
+            },
+        );
+
+        expect(result).toEqual({
+            valid: true,
+            errors: [],
+            warnings: [],
+            states: {
+                default: {
+                    toolName: { mode: 'chose', label: 'Fetch Tool', nested: argumentsSpec },
+                },
+            },
+        });
+    });
+
+    it('should emit the chosen static option nested spec on the field state', async () => {
+        const result = await validateForman(
+            { toolName: 'fetch-tool', arguments: { url: 'https://example.com' } },
+            [
+                {
+                    name: 'toolName',
+                    type: 'select',
+                    options: [
+                        { value: 'fetch-tool', label: 'Fetch Tool', nested: argumentsSpec },
+                        { value: 'other-tool', label: 'Other Tool' },
+                    ],
+                },
+            ],
+            { states: true },
+        );
+
+        expect(result).toEqual({
+            valid: true,
+            errors: [],
+            warnings: [],
+            states: {
+                default: {
+                    toolName: { mode: 'chose', label: 'Fetch Tool', nested: argumentsSpec },
+                },
+            },
+        });
+    });
+
+    it('should not emit a nested member when the chosen option has none', async () => {
+        const result = await validateForman(
+            { toolName: 'other-tool' },
+            [
+                {
+                    name: 'toolName',
+                    type: 'select',
+                    options: [
+                        { value: 'fetch-tool', label: 'Fetch Tool', nested: argumentsSpec },
+                        { value: 'other-tool', label: 'Other Tool' },
+                    ],
+                },
+            ],
+            { states: true },
+        );
+
+        expect(result).toEqual({
+            valid: true,
+            errors: [],
+            warnings: [],
+            states: {
+                default: {
+                    toolName: { mode: 'chose', label: 'Other Tool' },
+                },
+            },
+        });
+    });
+
+    it('should emit the placeholder nested spec on the field state for empty values', async () => {
+        const placeholderNested = [{ name: 'defaultField', type: 'text', label: 'Default Field' }];
+        const result = await validateForman(
+            { aggregator: '' },
+            [
+                {
+                    name: 'aggregator',
+                    type: 'select',
+                    options: {
+                        store: [
+                            { value: 'sum', label: 'Sum' },
+                            { value: 'avg', label: 'Average' },
+                        ],
+                        placeholder: {
+                            label: 'Select an aggregator...',
+                            nested: placeholderNested,
+                        },
+                    },
+                },
+            ],
+            { states: true },
+        );
+
+        expect(result).toEqual({
+            valid: true,
+            errors: [],
+            warnings: [],
+            states: {
+                default: {
+                    aggregator: { mode: 'chose', label: 'Select an aggregator...', nested: placeholderNested },
+                },
+            },
+        });
+    });
+
+    it('should keep the spec array intact when a dependent field emits its own state', async () => {
+        const nestedWithSelect = [
+            {
+                name: 'mode',
+                type: 'select',
+                label: 'Mode',
+                options: [
+                    { value: 'fast', label: 'Fast' },
+                    { value: 'slow', label: 'Slow' },
+                ],
+            },
+        ];
+        const result = await validateForman(
+            { toolName: 'fetch-tool', mode: 'fast' },
+            [{ name: 'toolName', type: 'select', options: 'rpc://listTools' }],
+            {
+                states: true,
+                resolveRemote() {
+                    return Promise.resolve([{ value: 'fetch-tool', label: 'Fetch Tool', nested: nestedWithSelect }]);
+                },
+            },
+        );
+
+        // Dependent field states are siblings of the select state; the spec array on the
+        // select's state must survive buildRestoreStructure untouched.
+        expect(result).toEqual({
+            valid: true,
+            errors: [],
+            warnings: [],
+            states: {
+                default: {
+                    toolName: { mode: 'chose', label: 'Fetch Tool', nested: nestedWithSelect },
+                    mode: { mode: 'chose', label: 'Fast' },
+                },
+            },
+        });
+    });
+});

--- a/test/validator-manifest.spec.ts
+++ b/test/validator-manifest.spec.ts
@@ -2,6 +2,30 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from '@jest/globals';
 import { validateForman, validateFormanWithDomains } from '../src/index.js';
 
+/** Finds the first field definition with the given name anywhere in a manifest. */
+function findFieldByName(node: unknown, name: string): Record<string, any> | undefined {
+    if (Array.isArray(node)) {
+        for (const item of node) {
+            const found = findFieldByName(item, name);
+            if (found) return found;
+        }
+    } else if (node && typeof node === 'object') {
+        const record = node as Record<string, any>;
+        if (record.name === name && record.options) return record;
+        for (const key of Object.keys(record)) {
+            const found = findFieldByName(record[key], name);
+            if (found) return found;
+        }
+    }
+    return undefined;
+}
+
+/** Returns the `nested` spec of the option with the given value on a select field. */
+function chosenOptionNested(field: Record<string, any>, value: unknown): unknown {
+    const store = Array.isArray(field.options) ? field.options : field.options.store;
+    return store.find((option: Record<string, any>) => option.value === value)?.nested;
+}
+
 describe('Forman Schema Manifest Validation', () => {
     it('should validate google-sheets manifest', async () => {
         const googleSheetsAddRowMock = JSON.parse(readFileSync('./test/mocks/google-sheets-add-row.json').toString());
@@ -162,10 +186,12 @@ describe('Forman Schema Manifest Validation', () => {
                     from: {
                         label: 'My Drive',
                         mode: 'chose',
+                        nested: chosenOptionNested(findFieldByName(googleSheetsAddRowMock, 'from')!, 'drive'),
                     },
                     includesHeaders: {
                         label: 'Yes',
                         mode: 'chose',
+                        nested: 'rpc://google-sheets@2/rpcSheetInput',
                     },
                     insertDataOption: {
                         label: 'Insert rows',
@@ -174,6 +200,7 @@ describe('Forman Schema Manifest Validation', () => {
                     mode: {
                         label: 'Search by path',
                         mode: 'chose',
+                        nested: chosenOptionNested(findFieldByName(googleSheetsAddRowMock, 'mode')!, 'select'),
                     },
                     valueInputOption: {
                         label: 'User entered',


### PR DESCRIPTION
## Problem

When `validateForman*({ states: true })` emits field states for select-like fields, the chosen option's dependent-fields specification (`option.nested` / `placeholder.nested`) was discarded. The validator resolves and validates dependent values against the option's `nested` spec, but the emitted state was only `{ mode: 'chose', label }` — the spec was dropped by the `Omit<FormanSchemaFieldState, 'nested' | 'items'>` narrowing in place since field states were introduced (#19).

Consumers that rebuild a restore structure from these states therefore lose the dependent-fields section for chosen options.

## Fix

- Emit the nested spec on `chose` states in both the chosen-option branch and the `placeholder.nested` branch of `handleSelectType`.
- Widen `FormanSchemaFieldState.nested` to `Record<string, FormanSchemaFieldState> | FormanSchemaNested` — the restore format uses both shapes (record of child states on collections, spec array on chose-selects).
- Lift `'nested'` from the `Omit` at the three state-typing sites (`DomainRoot.fieldStates`, `buildRestoreStructure` input; the `fieldStateMap` derives).
- Defensive guard in `buildRestoreStructure` path navigation: child states take precedence if a spec ever occupies the same `nested` key (can't happen today — dependent select fields emit sibling-path states — locked in by test).

## Blast radius

Additive output change: any consumer of `validateForman*` with `states: true` now receives `nested` on chose states whose option carries a spec. `FormanSchemaFieldState` is not exported from the public API, so no type-contract break.

## Tests

- New `test/chosen-option-nested.spec.ts`: RPC option spec, static option spec, no-nested option (no key emitted), placeholder spec, and sibling-state/spec-array coexistence.
- `test/validator-manifest.spec.ts` google-sheets expectations updated — the real manifest now shows `mode`/`from`/`includesHeaders` chose states carrying their option specs (including a string RPC-ref spec).
- Full suite: 360/360, lint + build clean.

## Release

Please cut a release (suggest **1.16.0**) once merged.
