### PR TITLE
chore: release 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@makehq/forman-schema",
-            "version": "1.15.0",
+            "version": "1.16.0",
             "license": "MIT",
             "devDependencies": {
                 "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makehq/forman-schema",
-    "version": "1.15.0",
+    "version": "1.16.0",
     "description": "Forman Schema Tools",
     "license": "MIT",
     "author": "Make",


### PR DESCRIPTION
Version bump to **1.16.0** ahead of cutting the GitHub release.

Includes the merged fix (#56): the validator now emits the chosen-option nested spec in field states.

Once merged, creating the `v1.16.0` GitHub release triggers the npm + JSR publish workflows.